### PR TITLE
Adding specs

### DIFF
--- a/spec/features/dice_spec.rb
+++ b/spec/features/dice_spec.rb
@@ -1,0 +1,86 @@
+describe "root URL" do
+  it "has a level one heading with the text 'Dice Roll'", points: 1 do
+    visit "/"
+
+    expect(page).to have_tag("h1", text: /Dice\s+Roll/i)
+  end
+end
+
+describe "root URL" do
+  it "has links to '/dice/X/Y', where 'X' is the number of dice, and 'Y' is the number of sides", points: 1 do
+    visit "/"
+
+    expect(page).to have_tag("a", :with => { :href => "/dice/2/6" })
+    expect(page).to have_tag("a", :with => { :href => "/dice/2/10" })
+    expect(page).to have_tag("a", :with => { :href => "/dice/1/20" })
+    expect(page).to have_tag("a", :with => { :href => "/dice/5/4" })
+  end
+end
+
+describe "/dice/2/6" do
+  it "has a level one heading with the text '2d6'", points: 1 do
+    visit "/dice/2/6"
+
+    expect(page).to have_tag("h1", text: /2d6/i)
+  end
+end
+
+describe "/dice/2/6" do
+  it "displays the outcome of rolling two six-sided dice", points: 1 do
+    visit "/dice/2/6"
+    
+    expect(page).to have_content(/You\s+rolled\s+a\s+\d+\s+and\s+a\s+\d+\s+for\s+a\s+total\s+of\s+\d+/),
+      "Expected page to display 'You rolled a X and a Y for a total of Z.' where X and Y are the two dice and Z is the sum."
+  end
+end
+
+describe "/dice/2/10" do
+  it "has a level one heading with the text '2d10'", points: 1 do
+    visit "/dice/2/10"
+
+    expect(page).to have_tag("h1", text: /2d10/i)
+  end
+end
+
+describe "/dice/2/10" do
+  it "displays the outcome of rolling two 10-sided dice", points: 1 do
+    visit "/dice/2/10"
+    
+    expect(page).to have_content(/You\s+rolled\s+a\s+\d+\s+and\s+a\s+\d+\s+for\s+a\s+total\s+of\s+\d+/),
+      "Expected page to display 'You rolled a X and a Y for a total of Z.' where X and Y are the two dice and Z is the sum."
+  end
+end
+
+describe "/dice/1/20" do
+  it "has a level one heading with the text '1d20'", points: 1 do
+    visit "/dice/1/20"
+
+    expect(page).to have_tag("h1", text: /1d20/i)
+  end
+end
+
+describe "/dice/1/20" do
+  it "displays the outcome of rolling one 20-sided dice", points: 1 do
+    visit "/dice/1/20"
+    
+    expect(page).to have_content(/You\s+rolled\s+a\s+\d+/),
+      "Expected page to display 'You rolled a X.' where X is the dice."
+  end
+end
+
+describe "/dice/5/4" do
+  it "has a level one heading with the text '5d4'", points: 1 do
+    visit "/dice/5/4"
+
+    expect(page).to have_tag("h1", text: /5d4/i)
+  end
+end
+
+describe "/dice/5/4" do
+  it "displays the outcome of rolling five four-sided dice", points: 1 do
+    visit "/dice/5/4"
+    
+    expect(page).to have_content(/You\s+rolled\s+a\s+\d+,\s+\d+,\s+\d+,\s+\d+,\s+and\s+\d+\s+for\s+a\s+total\s+of\s+\d+/)
+      "Expected page to display 'You rolled a U, V, W, X, and Y for a total of Z.' where U, V, W, X, and Y are the dice and Z is the sum."
+  end
+end

--- a/spec/features/dice_spec.rb
+++ b/spec/features/dice_spec.rb
@@ -84,3 +84,21 @@ describe "/dice/5/4" do
       "Expected page to display 'You rolled a U, V, W, X, and Y for a total of Z.' where U, V, W, X, and Y are the dice and Z is the sum."
   end
 end
+
+describe "/dice/50/6" do
+  it "has a level one heading with the text '50d6'", points: 1 do
+    visit "/dice/50/6"
+
+    expect(page).to have_tag("h1", text: /50d6/i)
+  end
+end
+
+describe "/dice/50/6" do
+  it "displays the outcome of rolling fifty six-sided dice in in <li>'s of an unordered list", points: 1 do
+    visit "/dice/50/6"
+
+    expect(page).to have_tag("ul") do
+      with_tag("li", :text => /\d+/, :count => 50)
+    end
+  end
+end

--- a/spec/features/sample_spec.rb
+++ b/spec/features/sample_spec.rb
@@ -1,5 +1,0 @@
-describe "This project" do
-  it "has no tests" do
-    expect(1).to eq(1)
-  end
-end


### PR DESCRIPTION
**NOTE: This PR needs to be merged first: https://github.com/appdev-projects/sinatra-dice-dynamic/pull/2, prior to finishing here.**

# Problem

The specs in this PR currently check for the ending point of `sinatra-dice-roll`. However, that project has a very different output on the view templates compared to the ending point of this project, where we refactor and delete old code.

If the goal is to show how automated tests can help with refactoring, then the first project should end with view templates that look like:

```erb
<h1>5d4</h1>

<ul>
  <% @rolls.each do |a_roll| %>
    <li>
      <%= a_roll %>
    </li>
  <% end %>
</ul>
```

Rather than, as the view templates appear now, and as the specs are testing for:

```erb
<h1>5d4</h1>

<p><%= @outcome %></p>
```

By changing the view templates, the specs could be written like:

```ruby
describe "/dice/5/4" do
  it "displays the outcome of rolling fifty six-sided dice in in <li>'s of an unordered list", points: 1 do
    visit "/dice/5/4"

    expect(page).to have_tag("ul") do
      with_tag("li", :text => /\d+/, :count => 5)
    end
  end
end
```

Rather than how they are now, which **will not pass** after a refactoring:

```ruby
describe "/dice/5/4" do
  it "displays the outcome of rolling five four-sided dice", points: 1 do
    visit "/dice/5/4"
    
    expect(page).to have_content(/You rolled a \d+, \d+, \d+, \d+, and \d+ for a total of \d+/)
      "Expected page to display 'You rolled a U, V, W, X, and Y for a total of Z.' where U, V, W, X, and Y are the dice and Z is the sum."
  end
end
```

# Solution

The end of [the `sinatra-dice-roll` view templates lesson](https://checkins.firstdraft.com/lessons/105#looping-in-view-templates) does include the view template format that we want to test for.

**We should update the _starting point_ of this lesson by modifying the current view templates (e.g. `two_six.erb`) and `app.rb` action code to use `.each` looping and an `@rolls` instance variable.**

Then we can write the specs sensibly such that a refactoring won't break things.

Thoughts, @raghubetina?